### PR TITLE
Fix deprecated code

### DIFF
--- a/UITextField-Navigation/Classes/NavigationFieldToolbar.swift
+++ b/UITextField-Navigation/Classes/NavigationFieldToolbar.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol NavigationFieldToolbarDelegate: class {
+protocol NavigationFieldToolbarDelegate: AnyObject {
 
     func navigationFieldToolbarDidTapPreviousButton(_ navigationFieldToolbar: NavigationFieldToolbar)
     func navigationFieldToolbarDidTapNextButton(_ navigationFieldToolbar: NavigationFieldToolbar)


### PR DESCRIPTION
Fix warning: `Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead`